### PR TITLE
Persist root homedir in docker-compose file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,3 +25,4 @@ services:
     volumes:
     - ./data/customers:/var/customers
     - ./data/system:/var/system
+    - ./data/root-homedir:/root


### PR DESCRIPTION
As froxlor tracks its acme config inside /root/.acme.sh/ this directory should be persisted as well (like already done in the helmchart)